### PR TITLE
T1036: Change priority on opennhrp to make it start after vpn is up

### DIFF
--- a/templates-cfg/protocols/nhrp/node.def
+++ b/templates-cfg/protocols/nhrp/node.def
@@ -1,5 +1,5 @@
 help: NHRP parameters
 
-priority: 740
+priority: 991
 
 end: sudo /opt/vyatta/sbin/vyos-update-nhrp.pl --set_nhrp;


### PR DESCRIPTION
Ref: https://phabricator.vyos.net/T1036