### PR TITLE
dmvpn: T1784: Fix issue with opennhrp.init

### DIFF
--- a/etc/init.d/opennhrp.init
+++ b/etc/init.d/opennhrp.init
@@ -32,7 +32,7 @@ DAEMON_ARGS=" -d -a $CTRLPIPE -c $CONFFILE -s $SCRIPTFILE -p $PIDFILE"
 [ -x "$DAEMON" ] || exit 0
 
 # Exclude from systemd
-_SYSTEMCTL_SKIP_REDIRECT=yes
+SYSTEMCTL_SKIP_REDIRECT=yes
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME


### PR DESCRIPTION
"* debian/extra/init-functions.d/40-systemd: Rename _SYSTEMCTL_SKIP_REDIRECT.
    Rename _SYSTEMCTL_SKIP_REDIRECT to SYSTEMCTL_SKIP_REDIRECT to be more
    consistent with other environment variables which are used internally by
    systemd, like SYSTEMCTL_SKIP_SYSV."