### PR TITLE
nhrp: T4152: Fix shortcut-target holding-time settings

### DIFF
--- a/scripts/vyos-update-nhrp.pl
+++ b/scripts/vyos-update-nhrp.pl
@@ -221,7 +221,9 @@ sub tunnel_config {
 		my @starget = $tunnel_Config->listNodes("$tunnel_ID shortcut-target");
 		my $starget = $starget[0];
 		push(@conf_file, " shortcut-target", " $starget");
-		push(@conf_file, " ", $tunnel_Config->returnValue("$tunnel_ID shortcut-target $starget holding-time"));
+                if ( $tunnel_Config->exists("$tunnel_ID shortcut-target $starget holding-time")) {
+                    push(@conf_file, " holding-time ", $tunnel_Config->returnValue("$tunnel_ID shortcut-target $starget holding-time"));
+                }
 		shift(@conf_file);
 		unshift(@conf_file, "interface $tunnel_ID $type\n");
 		push(@conf_file, "\n");


### PR DESCRIPTION
Fix shortcut-target holding time option
It was miss word `holding-time` in `opennhrp.conf` configuration for `shortcut-target x.x.x.x` in opennhrp.conf

https://phabricator.vyos.net/T4152

Tested configuration:
```
set interfaces tunnel tun0 encapsulation 'gre'
set interfaces tunnel tun0 source-interface 'eth0'

set protocols nhrp tunnel tun0 cisco-authentication foo
set protocols nhrp tunnel tun0 holding-time '300'
set protocols nhrp tunnel tun0 map 10.0.0.1/20 nbma-address '10.0.112.72'
set protocols nhrp tunnel tun0 map 10.0.0.1/20 register
set protocols nhrp tunnel tun0 multicast 'nhs'
set protocols nhrp tunnel tun0 redirect
set protocols nhrp tunnel tun0 shortcut
set protocols nhrp tunnel tun0 shortcut-target 10.0.0.1/20 holding-time '15'
```
Before fix:
```
vyos@r4# sudo cat /etc/opennhrp/opennhrp.conf 
interface tun0 #spoke
 map 10.0.0.1/20 10.0.112.72 register
 shortcut-target 10.0.0.1/20 15
```
After fix (expected `holding-time 15`):
```
...
vyos@r4# sudo cat /etc/opennhrp/opennhrp.conf 
interface tun0 #spoke
 map 10.0.0.1/20 10.0.112.72 register
 shortcut-target 10.0.0.1/20 holding-time 15

```